### PR TITLE
Add PPTX upload UI and Swagger docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -9,7 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   slide.addText(`Bonjour ${Nom}`, { x: 1, y: 1, fontSize: 18 });
   slide.addText(`Votre RDV est prévu pour le ${Date}`, { x: 1, y: 2, fontSize: 14 });
 
-  const buffer = await pptx.write("nodebuffer");
+  const buffer = (await pptx.write({ outputType: "nodebuffer" })) as Buffer;
 
   res.setHeader("Content-Disposition", "attachment; filename=generated.pptx");
   res.setHeader("Content-Type", "application/vnd.openxmlformats-officedocument.presentationml.presentation");

--- a/pages/api/populate.ts
+++ b/pages/api/populate.ts
@@ -1,0 +1,54 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import JSZip from "jszip";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  try {
+    const { pptxBase64, values } = req.body as {
+      pptxBase64: string;
+      values: Record<string, string>;
+    };
+
+    if (!pptxBase64 || !values) {
+      res.status(400).json({ error: "pptxBase64 and values are required" });
+      return;
+    }
+
+    const buffer = Buffer.from(pptxBase64, "base64");
+    const zip = await JSZip.loadAsync(buffer);
+
+    const slideRegex = /^ppt\/slides\/slide\d+\.xml$/;
+    const files = Object.keys(zip.files).filter((name) => slideRegex.test(name));
+
+    for (const name of files) {
+      const file = zip.file(name);
+      if (!file) continue;
+      let content = await file.async("string");
+      for (const [key, value] of Object.entries(values)) {
+        const placeholder = `<<[${key}]>>`;
+        const regex = new RegExp(placeholder, "g");
+        content = content.replace(regex, value);
+      }
+      zip.file(name, content);
+    }
+
+    const newBuffer = await zip.generateAsync({ type: "nodebuffer" });
+
+    res.setHeader(
+      "Content-Disposition",
+      "attachment; filename=modified.pptx"
+    );
+    res.setHeader(
+      "Content-Type",
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    );
+    res.send(newBuffer);
+  } catch (err: any) {
+    console.error(err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,10 +6,20 @@ export default function Home() {
   const [date, setDate] = useState("10/07/2025");
   const [status, setStatus] = useState("");
 
+  const [file, setFile] = useState<File | null>(null);
+  const [jsonText, setJsonText] = useState('{"NomProjet":"Demo"}');
+  const [populateStatus, setPopulateStatus] = useState("");
+
   const handleGenerate = async () => {
     setStatus("Génération en cours...");
-    const response = await axios.post("/api/generate", { Nom: nom, Date: date }, { responseType: "blob" });
-    const blob = new Blob([response.data], { type: "application/vnd.openxmlformats-officedocument.presentationml.presentation" });
+    const response = await axios.post(
+      "/api/generate",
+      { Nom: nom, Date: date },
+      { responseType: "blob" }
+    );
+    const blob = new Blob([response.data], {
+      type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    });
     const url = window.URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
@@ -18,6 +28,44 @@ export default function Home() {
     link.click();
     link.remove();
     setStatus("Fichier généré !");
+  };
+
+  const handlePopulate = async () => {
+    if (!file) {
+      setPopulateStatus("Veuillez sélectionner un fichier PPTX");
+      return;
+    }
+    setPopulateStatus("Envoi en cours...");
+    try {
+      const base64 = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const result = reader.result as string;
+          resolve(result.split(",")[1]);
+        };
+        reader.onerror = () => reject(reader.error);
+        reader.readAsDataURL(file);
+      });
+      const values = JSON.parse(jsonText);
+      const response = await axios.post(
+        "/api/populate",
+        { pptxBase64: base64, values },
+        { responseType: "blob" }
+      );
+      const blob = new Blob([response.data], {
+        type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", "modified.pptx");
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      setPopulateStatus("Fichier modifié téléchargé !");
+    } catch (err: any) {
+      setPopulateStatus("Erreur: " + err.message);
+    }
   };
 
   return (
@@ -31,8 +79,39 @@ export default function Home() {
         <label>Date : </label>
         <input value={date} onChange={(e) => setDate(e.target.value)} />
       </div>
-      <button onClick={handleGenerate} style={{ padding: "0.5rem 1rem" }}>Générer PPTX</button>
+      <button onClick={handleGenerate} style={{ padding: "0.5rem 1rem" }}>
+        Générer PPTX
+      </button>
       <p>{status}</p>
+
+      <hr style={{ margin: "2rem 0" }} />
+
+      <h2>📥 Remplir un PPTX existant</h2>
+      <div style={{ marginBottom: "1rem" }}>
+        <input
+          type="file"
+          accept=".pptx"
+          onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
+        />
+      </div>
+      <div style={{ marginBottom: "1rem" }}>
+        <textarea
+          rows={4}
+          cols={50}
+          value={jsonText}
+          onChange={(e) => setJsonText(e.target.value)}
+        />
+      </div>
+      <button onClick={handlePopulate} style={{ padding: "0.5rem 1rem" }}>
+        Envoyer
+      </button>
+      <p>{populateStatus}</p>
+
+      <div style={{ marginTop: "2rem" }}>
+        <a href="/api-docs.html" target="_blank" rel="noopener">
+          📑 Documentation API
+        </a>
+      </div>
     </div>
   );
 }

--- a/public/api-docs.html
+++ b/public/api-docs.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" />
+  <title>API Docs</title>
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+  <script>
+    window.onload = function() {
+      SwaggerUIBundle({ url: '/openapi.json', dom_id: '#swagger-ui' });
+    };
+  </script>
+</body>
+</html>

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "PPTX API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/api/generate": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "Nom": { "type": "string" },
+                  "Date": { "type": "string" }
+                },
+                "required": ["Nom", "Date"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Generated PPTX",
+            "content": {
+              "application/vnd.openxmlformats-officedocument.presentationml.presentation": {
+                "schema": { "type": "string", "format": "binary" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/populate": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pptxBase64": { "type": "string" },
+                  "values": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                  }
+                },
+                "required": ["pptxBase64", "values"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Modified PPTX",
+            "content": {
+              "application/vnd.openxmlformats-officedocument.presentationml.presentation": {
+                "schema": { "type": "string", "format": "binary" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add form to upload PPTX and JSON values
- expose `/api-docs.html` with Swagger UI using openapi spec
- provide openapi.json specification for both endpoints

## Testing
- `npm run build` *(fails: `next` not found)*


------
https://chatgpt.com/codex/tasks/task_e_686f923aec2483219eb5c47af970fbfd