### PR TITLE
Increase API body size limit

### DIFF
--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -15,3 +15,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   res.setHeader("Content-Type", "application/vnd.openxmlformats-officedocument.presentationml.presentation");
   res.send(buffer);
 }
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "100mb",
+    },
+  },
+};

--- a/pages/api/populate.ts
+++ b/pages/api/populate.ts
@@ -70,3 +70,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     res.status(500).json({ error: "Internal server error" });
   }
 }
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "100mb",
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- add custom bodyParser size limit for `/api/generate`
- add custom bodyParser size limit for `/api/populate`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd5641564832194324772c01cb703