### PR TITLE
Fix regex creation in PPTX populate API

### DIFF
--- a/pages/api/populate.ts
+++ b/pages/api/populate.ts
@@ -39,9 +39,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       target: string,
       replacement: string
     ) => {
-      const pattern = escapeRegex(target)
+      const pattern = target
         .split("")
-        .map((c) => `${c}(?:<\/a:t>\s*<a:t[^>]*>)?`)
+        .map((c) => `${escapeRegex(c)}(?:<\/a:t>\s*<a:t[^>]*>)?`)
         .join("");
       return xml.replace(new RegExp(pattern, "g"), replacement);
     };


### PR DESCRIPTION
## Summary
- ensure placeholder regex escapes individual characters

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_687119754f608321828164c51d339050