### PR TITLE
Remove PPTX generator UI

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,35 +2,11 @@ import { useState } from "react";
 import axios from "axios";
 
 export default function Home() {
-  const [nom, setNom] = useState("Firas");
-  const [date, setDate] = useState("10/07/2025");
-  const [status, setStatus] = useState("");
-
   const [file, setFile] = useState<File | null>(null);
   const [jsonText, setJsonText] = useState('{"NomProjet":"Demo"}');
   const [populateStatus, setPopulateStatus] = useState("");
   const [uploadProgress, setUploadProgress] = useState(0);
   const [isUploading, setIsUploading] = useState(false);
-
-  const handleGenerate = async () => {
-    setStatus("Génération en cours...");
-    const response = await axios.post(
-      "/api/generate",
-      { Nom: nom, Date: date },
-      { responseType: "blob" }
-    );
-    const blob = new Blob([response.data], {
-      type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-    });
-    const url = window.URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.setAttribute("download", "generated.pptx");
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
-    setStatus("Fichier généré !");
-  };
 
   const handlePopulate = async () => {
     if (!file) {
@@ -83,21 +59,6 @@ export default function Home() {
 
   return (
     <div style={{ padding: "2rem", fontFamily: "Arial, sans-serif" }}>
-      <h1>🧩 Générateur PowerPoint</h1>
-      <div style={{ marginBottom: "1rem" }}>
-        <label>Nom : </label>
-        <input value={nom} onChange={(e) => setNom(e.target.value)} />
-      </div>
-      <div style={{ marginBottom: "1rem" }}>
-        <label>Date : </label>
-        <input value={date} onChange={(e) => setDate(e.target.value)} />
-      </div>
-      <button onClick={handleGenerate} style={{ padding: "0.5rem 1rem" }}>
-        Générer PPTX
-      </button>
-      <p>{status}</p>
-
-      <hr style={{ margin: "2rem 0" }} />
 
       <h2>📥 Remplir un PPTX existant</h2>
       <div style={{ marginBottom: "1rem" }}>


### PR DESCRIPTION
## Summary
- remove the PowerPoint generator section from the home page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688782c1b1088321856aa87b21583480