### PR TITLE
Add placeholder replacement utility

### DIFF
--- a/utils/replacePlaceholders.ts
+++ b/utils/replacePlaceholders.ts
@@ -1,0 +1,5 @@
+export function replacePlaceholders(text: string, values: Record<string, string>): string {
+  return text.replace(/<<\[(.+?)\]>>/g, (_match, key) => {
+    return Object.prototype.hasOwnProperty.call(values, key) ? values[key] : _match;
+  });
+}


### PR DESCRIPTION
## Summary
- add a simple utility to replace `<<[key]>>` markers with JSON values

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*
- `npm install` *(fails due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_688782af49c083219f61c543f0c31887