### PR TITLE
Update placeholder syntax

### DIFF
--- a/pages/api/populate.ts
+++ b/pages/api/populate.ts
@@ -56,8 +56,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       if (!file) continue;
       let content = await file.async("string");
       for (const [key, value] of Object.entries(values)) {
-        const placeholder = `<<[${key}]>>`;
-        const encoded = placeholder.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+        const placeholder = `{{${key}}}`;
+        const encoded = placeholder; // curly braces don't require XML encoding
         const escaped = xmlEscape(value);
 
         let result = replaceAcrossTags(content, placeholder, escaped);

--- a/utils/replacePlaceholders.ts
+++ b/utils/replacePlaceholders.ts
@@ -1,5 +1,5 @@
 export function replacePlaceholders(text: string, values: Record<string, string>): string {
-  return text.replace(/<<\[(.+?)\]>>/g, (_match, key) => {
+  return text.replace(/{{\s*(.+?)\s*}}/g, (_match, key) => {
     return Object.prototype.hasOwnProperty.call(values, key) ? values[key] : _match;
   });
 }


### PR DESCRIPTION
## Summary
- switch placeholder syntax to `{{key}}`
- adjust API placeholder replacement

## Testing
- `npm install` *(fails: registry blocked)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68878baa60b48321a8e4cd66770e5b2f