### PR TITLE
Fix regex replacement in populate API

### DIFF
--- a/pages/api/populate.ts
+++ b/pages/api/populate.ts
@@ -46,6 +46,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         .join("");
       const regex = new RegExp(pattern, "g");
       const matched = regex.test(xml);
+      if (!matched) return { xml, matched };
+      regex.lastIndex = 0;
       return { xml: xml.replace(regex, replacement), matched };
     };
 


### PR DESCRIPTION
## Summary
- preserve regex start position when replacing placeholders across XML tags

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_688792b4644c8321aa8edf9d5ac9466e