### PR TITLE
Fix line break removal in tag replacement

### DIFF
--- a/pages/api/populate.ts
+++ b/pages/api/populate.ts
@@ -48,7 +48,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const matched = regex.test(xml);
       if (!matched) return { xml, matched };
       regex.lastIndex = 0;
-      return { xml: xml.replace(regex, replacement), matched };
+      return {
+        xml: xml.replace(regex, (m) => {
+          const newlines = m.match(/[\r\n]+/g)?.join("") || "";
+          return replacement + newlines;
+        }),
+        matched,
+      };
     };
 
     const foundKeys = new Set<string>();


### PR DESCRIPTION
## Summary
- preserve line breaks when replacing placeholders across XML tags

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688794b33f308321b91067d953468763